### PR TITLE
Hash invalid public keys to fix halted sync on special blocks

### DIFF
--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -497,7 +497,8 @@ export class Crypto {
      */
     public async generateKeyDerivation (public_key: string, private_key: string): Promise<string> {
         if (!await this.checkKey(public_key)) {
-            throw new Error('Invalid public key found');
+            //If someone sends an invalid public key, ignore it and just hash it
+            public_key = await this.cn_fast_hash(public_key)
         }
         if (!await this.checkScalar(private_key)) {
             throw new Error('Invalid private key found');

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -498,6 +498,9 @@ export class Crypto {
     public async generateKeyDerivation (public_key: string, private_key: string): Promise<string> {
         if (!await this.checkKey(public_key)) {
             //If someone sends an invalid public key, ignore it and just hash it
+            if (!isHex64(public_key)) {
+                throw new Error('Invalid public key found');
+            }
             public_key = await this.cn_fast_hash(public_key)
         }
         if (!await this.checkScalar(private_key)) {


### PR DESCRIPTION
Many users have reported getting stuck syncing at specific blocks. This seems to be due to an invalid public key being sent. Right now it throws an error and get stuck. I propose a solution where we just hash the invalid key to a with cn_fast_hash() and just ignore it.  I am not sure if we should do extra verification on chain for these types of events. My initial thought is that if it is an attack, someone is just spending money with invalid keys. This PR solves wallets getting stuck if it where to happen again.